### PR TITLE
docs: add opt-in process documentation

### DIFF
--- a/OPT_IN_STORY.md
+++ b/OPT_IN_STORY.md
@@ -1,0 +1,46 @@
+**Proof of Consent: Opt-In Process for LangGang's Charades Game**
+
+LangGang ensures that all users who receive text messages for the Charades game explicitly consent to communication through a clear and transparent opt-in process. Below is an outline of how we collect and document consent from our users:
+
+---
+
+### **Overview of the Opt-In Process**
+LangGang offers users the ability to participate in the interactive Charades game via SMS. To ensure compliance with messaging regulations and maintain user trust, we require all participants to provide explicit consent before receiving any messages. Users can opt in through the following method:
+
+1. **SMS-Based Consent**
+   - Users initiate the opt-in process by texting the toll-free number provided for LangGang's Charades game.
+   - Upon receiving the user's initial message, an automated reply is sent confirming their interest and requesting explicit consent.
+     - Example reply: *"Thank you for your interest in LangGang's Charades game! Reply YES to confirm your participation and start receiving game prompts. Message and data rates may apply."*
+   - Users must reply "YES" to confirm their consent.
+
+2. **Backend Confirmation**
+   - Once the user replies "YES," their phone number and consent details are logged securely in our database.
+   - A confirmation message is sent via Twilio to the user’s provided phone number. Example:
+     *"You are now signed up for LangGang's Charades game! Reply STOP at any time to opt out."*
+
+3. **Ongoing Consent Management**
+   - Users retain full control over their participation and can opt out at any time by replying STOP to any message received.
+
+---
+
+### **Supporting Evidence**
+
+To demonstrate proof of consent, the following resources are available:
+
+1. **SMS Interaction Logs**
+   - Logs of the initial message from the user and their "YES" reply are stored securely.
+   - Timestamped records of all consent-related interactions.
+
+2. **Database Records**
+   - We securely store records of user submissions, including:
+     - The phone number provided.
+     - Timestamp of consent.
+     - Confirmation of their "YES" reply.
+
+3. **Confirmation Messages**
+   - Sent messages are logged via Twilio, confirming user consent with a timestamp and message content.
+
+---
+
+This process ensures that all participants have voluntarily and explicitly opted into receiving SMS messages related to LangGang’s Charades game.
+


### PR DESCRIPTION
- Add detailed documentation of the SMS opt-in process for Charades game
- Include overview of consent collection process
- Document supporting evidence and record keeping
- Specify user control and opt-out procedures