### PR TITLE
refactor: update opt-out command and message formatting

### DIFF
--- a/src/charades/game/api.py
+++ b/src/charades/game/api.py
@@ -92,7 +92,7 @@ def handle_incoming_message(
     # Handle opt-in/opt-out
     if command == "langgang":
         return handle_opt_in(message.From)
-    elif command == "stop":
+    elif command == "optout":
         return handle_opt_out(message.From)
 
     # TODO: Implement game logic for language selection and word description

--- a/src/charades/game/utils.py
+++ b/src/charades/game/utils.py
@@ -21,17 +21,17 @@ def create_twiml_response(message: str) -> str:
 MESSAGES = {
     "opt_in_success": (
         "Welcome to LangGang Charades! 🎮 You're now opted in. "
-        "To start playing, send a language code (e.g. 'en' for English or 'ko' for"
-        " Korean). You can opt out at any time by replying STOP."
+        "To start playing, send a language code (e.g. EN for English or KO for"
+        " Korean). You can opt out at any time by replying OPTOUT."
     ),
     "opt_out_success": (
         "You've been successfully opted out of LangGang Charades. "
-        "Thanks for playing! Text LangGang to opt back in anytime."
+        "Thanks for playing! Text LANG to opt back in anytime."
     ),
     "already_opted_in": (
         "You're already opted in to LangGang Charades! "
-        "To play, send a language code (e.g. 'en' for English or 'ko' for Korean). "
-        "Or reply STOP to opt out."
+        "To play, send a language code (e.g. EN for English or KO for Korean). "
+        "Or reply OPTOUT to opt out."
     ),
     "error_generic": ("Sorry, something went wrong. Please try again later."),
 }


### PR DESCRIPTION
- Change opt-out command from `stop` to `optout` for consistency
- Update message formatting to use uppercase language codes (EN, KO)
- Simplify opt-in command reference in opt-out message
- Update message formatting for better readability