### PR TITLE
test: player command logic integration tests

### DIFF
--- a/justfile
+++ b/justfile
@@ -10,6 +10,10 @@ pre-commit:
 pyright:
     uv run pyright
 
+# Run pytest unit tests
+pytest:
+    uv run pytest test
+
 # Run Django development server
 django-runserver:
     uv run python manage.py runserver

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "django-stubs>=5.1.2",
     "python-dotenv>=1.0.1",
     "openai>=1.61.0",
+    "pytest-django>=4.9.0",
 ]
 
 [project.scripts]

--- a/test/charades/game/test_logic.py
+++ b/test/charades/game/test_logic.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pytest
 from django.conf import settings
 
-from charades.game.logic import handle_game_message
+from charades.game.logic import handle_game_message, handle_player_command
 from charades.game.logic import handle_language_selection
 from charades.game.logic import handle_opt_in
 from charades.game.logic import handle_opt_out
@@ -23,9 +23,9 @@ def phone_number(request):
     Generates a unique phone number for each test to avoid conflicts.
     """
     test_name = request.node.name
-    # Use the test name to generate a unique number
-    unique_num = abs(hash(test_name)) % 10000
-    return f"+1206555{unique_num:04d}"
+    # Use the test name and current time to generate a unique number
+    unique_num = abs(hash(f"{test_name}{request.node.nodeid}")) % 10000000
+    return f"+1206{unique_num:07d}"
 
 
 @pytest.fixture
@@ -288,3 +288,116 @@ class TestWordDescriptionLogic:
 
             assert response["code"] == 400
             assert "Failed to evaluate description" in response["twiml"]
+
+
+@pytest.mark.django_db
+class TestPlayerCommandLogic:
+    """Integration tests for player command handling logic."""
+
+    def test_opt_in_command(self, phone_number):
+        """Test handling of opt-in command."""
+        response = handle_player_command(phone_number, "langgang")
+
+        # Check response
+        assert response["code"] == 200
+        assert response["twiml"] == create_twiml_response(MESSAGES["opt_in_success"])
+
+        # Verify player was created and opted in
+        player = Player.objects.get(phone_number=phone_number)
+        assert player.is_active
+        assert player.opted_in_at
+        assert not player.opted_out_at
+
+    def test_opt_out_command(self, active_player, active_game_session):
+        """Test handling of opt-out command."""
+        response = handle_player_command(active_player.phone_number, "optout")
+
+        # Check response
+        assert response["code"] == 200
+        assert response["twiml"] == create_twiml_response(MESSAGES["opt_out_success"])
+
+        # Verify player was opted out
+        active_player.refresh_from_db()
+        assert not active_player.is_active
+        assert active_player.opted_out_at
+
+        # Verify game session was ended
+        active_game_session.refresh_from_db()
+        assert active_game_session.status == "timeout"
+        assert active_game_session.completed_at
+
+    def test_language_selection_command(self, active_player):
+        """Test handling of language selection command."""
+        with patch("charades.game.logic.get_random_word") as mock_get_word:
+            mock_get_word.return_value = "test"
+            response = handle_player_command(active_player.phone_number, "en")
+
+            # Check response
+            assert response["code"] == 200
+            assert (
+                MESSAGES["new_game"].format(
+                    language=settings.SUPPORTED_LANGUAGES["EN"],
+                    word="test",
+                )
+                in response["twiml"]
+            )
+
+            # Verify game session was created
+            session = active_player.gamesession_set.first()
+            assert session.word == "test"
+            assert session.language == "en"
+            assert session.status == "active"
+
+    def test_word_description_command(self, active_player, active_game_session):
+        """Test handling of word description command."""
+        with patch("charades.game.logic.evaluate_description") as mock_evaluate:
+            mock_evaluate.return_value = (85, "Good job!")
+            response = handle_player_command(
+                active_player.phone_number, "this is a test description"
+            )
+
+            # Check response
+            assert response["code"] == 200
+            assert (
+                MESSAGES["game_complete"].format(
+                    score=85,
+                    feedback="Good job!",
+                )
+                in response["twiml"]
+            )
+
+            # Verify game session was completed
+            active_game_session.refresh_from_db()
+            assert active_game_session.status == "completed"
+            assert active_game_session.score == 85
+            assert active_game_session.completed_at
+            assert active_game_session.user_description == "this is a test description"
+            assert active_game_session.feedback == "Good job!"
+
+    def test_command_from_inactive_player(self, player):
+        """Test handling command from an inactive player."""
+        response = handle_player_command(player.phone_number, "en")
+
+        # Check response indicates player needs to opt in
+        assert response["code"] == 200
+        assert response["twiml"] == create_twiml_response(MESSAGES["not_opted_in"])
+
+    def test_invalid_command_from_active_player(self, active_player):
+        """Test handling invalid command from an active player."""
+        response = handle_player_command(active_player.phone_number, "invalid command")
+
+        # Check response provides guidance
+        assert response["code"] == 200
+        assert response["twiml"] == create_twiml_response(MESSAGES["how_to_play"])
+
+    def test_command_error_handling(self, phone_number):
+        """Test error handling in command processing."""
+        with patch(
+            "charades.game.models.Player.get_or_create_player"
+        ) as mock_get_create:
+            mock_get_create.side_effect = Exception("Database error")
+            response = handle_player_command(phone_number, "langgang")
+
+            assert response["code"] == 400
+            expected_msg = create_twiml_response("Failed to opt in: Database error")
+            assert response["twiml"] == expected_msg

--- a/uv.lock
+++ b/uv.lock
@@ -133,6 +133,7 @@ dependencies = [
     { name = "django-ninja" },
     { name = "django-stubs" },
     { name = "openai" },
+    { name = "pytest-django" },
     { name = "python-dotenv" },
     { name = "twilio" },
 ]
@@ -156,6 +157,7 @@ requires-dist = [
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.1.0" },
     { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.349" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.4" },
+    { name = "pytest-django", specifier = ">=4.9.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.2.1" },
     { name = "twilio", specifier = ">=9.4.4" },
@@ -589,6 +591,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/05/35/30e0d83068951d90a01852cb1cef56e5d8a09d20c7f511634cc2f7e0372a/pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761", size = 1445919 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/11/92/76a1c94d3afee238333bc0a42b82935dd8f9cf8ce9e336ff87ee14d9e1cf/pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6", size = 343083 },
+]
+
+[[package]]
+name = "pytest-django"
+version = "4.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/c0/43c8b2528c24d7f1a48a47e3f7381f5ab2ae8c64634b0c3f4bd843063955/pytest_django-4.9.0.tar.gz", hash = "sha256:8bf7bc358c9ae6f6fc51b6cebb190fe20212196e6807121f11bd6a3b03428314", size = 84067 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/fe/54f387ee1b41c9ad59e48fb8368a361fad0600fe404315e31a12bacaea7d/pytest_django-4.9.0-py3-none-any.whl", hash = "sha256:1d83692cb39188682dbb419ff0393867e9904094a549a7d38a3154d5731b2b99", size = 23723 },
 ]
 
 [[package]]


### PR DESCRIPTION
- Add comprehensive test suite for player command handling logic
- Add pytest-django dependency for testing Django models
- Add pytest command to justfile
- Improve phone number generation in tests to avoid conflicts